### PR TITLE
Add description to settings screen and remove redundant "(overridden)"

### DIFF
--- a/src/Admin/Screen.php
+++ b/src/Admin/Screen.php
@@ -100,8 +100,32 @@ class Screen {
 	 */
 	public function render() {
 		?>
+		<style type="text/css">
+			.external-link > .dashicons {
+				font-size: 16px;
+				text-decoration: none;
+			}
+
+			.external-link:hover > .dashicons,
+			.external-link:focus > .dashicons {
+				text-decoration: none;
+			}
+		</style>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Feature Policies', 'feature-policy' ); ?></h1>
+
+			<p>
+				<?php esc_html_e( 'Feature Policy grants you control over how certain browser APIs and web features act on your site.', 'feature-policy' ); ?>
+				<?php
+				printf(
+					'<a class="external-link" href="%1$s" target="_blank">%2$s<span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+					esc_url( _x( 'https://developers.google.com/web/updates/2018/06/feature-policy', 'learn more link', 'feature-policy' ) ),
+					esc_html__( 'Learn more about Feature Policy', 'feature-policy' ),
+					/* translators: accessibility text */
+					esc_html__( '(opens in a new tab)', 'feature-policy' )
+				);
+				?>
+			</p>
 
 			<form action="options.php" method="post" novalidate="novalidate">
 				<?php settings_fields( self::PAGE_SLUG ); ?>

--- a/src/Admin/Screen.php
+++ b/src/Admin/Screen.php
@@ -196,9 +196,6 @@ class Screen {
 			}
 			?>
 		</select>
-		<?php if ( $origin !== $policy->default_origin ) : ?>
-			<?php esc_html_e( '(overridden)', 'feature-policy' ); ?>
-		<?php endif; ?>
 		<?php
 	}
 }


### PR DESCRIPTION
## Summary

* Add minimum description to Settings screen to briefly explain what Feature Policy does.
* Add Learn More link to https://developers.google.com/web/updates/2018/06/feature-policy
* Remove "(overridden)" suffix following dropdowns where the non-default is selected. The "(default)" suffix inside of the dropdown conveys that sufficiently I think.

## Checklist:
- [x] My code is tested.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
